### PR TITLE
Refactor idb connector

### DIFF
--- a/db_connection/IDBConnector.ts
+++ b/db_connection/IDBConnector.ts
@@ -1,6 +1,3 @@
-import { PrismaClient } from "@prisma/client"
-
 export interface IDBConnector {
-    client: PrismaClient
     RunQuery(query: string): Promise<any>
 }

--- a/db_connection/PrismaConnector.ts
+++ b/db_connection/PrismaConnector.ts
@@ -10,7 +10,7 @@ export class PrismaConnector implements IDBConnector {
     }
 
     public async RunQuery(query: string) {
-    return this.client.$queryRawUnsafe(query);
+        return this.client.$queryRawUnsafe(query);
     }
 
 }


### PR DESCRIPTION
Remove PrismaClient from IDConnector, which should be implementation agnostic. Don't know why I had it there.